### PR TITLE
Remove Apigen from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "6.2.2",
-		"apigen/apigen": "5.0.0-RC3",
 		"roave/better-reflection": "@dev"
 	},
 	"autoload": {


### PR DESCRIPTION
Because of dependency hell I would like to remove apigen from require-dev.